### PR TITLE
Performance improve and small fixes

### DIFF
--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -1,7 +1,6 @@
 package reaper
 
 import (
-	"fmt"
 	"log"
 	"time"
 

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -31,104 +31,109 @@ func Quit(quitC chan<- struct{}, doneC <-chan struct{}) {
 //###############//
 
 func reap(db *bolt.DB, options Options, quitC <-chan struct{}, doneC chan<- struct{}) {
+	// Create a new ticker
+	ticker := time.NewTicker(options.CheckInterval)
+
+	defer func() {
+		// Stop the ticker
+		ticker.Stop()
+	}()
+
 	var prevKey []byte
+
 	for {
-		// This slice is a buffer to save all expired session keys.
-		expiredSessionKeys := make([][]byte, 0)
+		select {
+		case <-quitC: // Check if a quit signal is sent.
+			doneC <- struct{}{}
+			return
+		case <-ticker.C: // Check if the ticker fires a signal.
+			// This slice is a buffer to save all expired session keys.
+			expiredSessionKeys := make([][]byte, 0)
 
-		// Start a bolt read transaction.
-		err := db.View(func(tx *bolt.Tx) error {
-			bucket := tx.Bucket(options.BucketName)
-			if bucket == nil {
-				return nil
-			}
-
-			c := bucket.Cursor()
-
-			var i int
-			var isExpired bool
-
-			for k, v := c.Seek(prevKey); ; k, v = c.Next() {
-				// If we hit the end of our sessions then
-				// exit and start over next time.
-				if k == nil {
-					prevKey = nil
+			// Start a bolt read transaction.
+			err := db.View(func(tx *bolt.Tx) error {
+				bucket := tx.Bucket(options.BucketName)
+				if bucket == nil {
 					return nil
 				}
 
-				i++
+				c := bucket.Cursor()
 
-				// The flag if the session is expired
-				isExpired = false
+				var i int
+				var isExpired bool
 
-				session, err := shared.Session(v)
-				if err != nil {
-					// Just remove the session with the invalid session data.
-					// Log the error first.
-					log.Printf("boltstore: removing session from database with invalid value: %v", err)
-					isExpired = true
-				} else if shared.Expired(session) {
-					isExpired = true
-				}
+				for k, v := c.Seek(prevKey); ; k, v = c.Next() {
+					// If we hit the end of our sessions then
+					// exit and start over next time.
+					if k == nil {
+						prevKey = nil
+						return nil
+					}
 
-				if isExpired {
-					// Copy the byte slice key, because this data is
-					// not safe outside of this transaction.
-					temp := make([]byte, len(k))
-					copy(temp, k)
+					i++
 
-					// Add it to the expired sessios keys slice
-					expiredSessionKeys = append(expiredSessionKeys, temp)
-				}
+					// The flag if the session is expired
+					isExpired = false
 
-				if options.BatchSize == i {
-					// Store the current key to the previous key.
-					// Copy the byte slice key, because this data is
-					// not safe outside of this transaction.
-					prevKey = make([]byte, len(k))
-					copy(prevKey, k)
-					return nil
-				}
-			}
-		})
-
-		if err != nil {
-			log.Printf("boltstore: obtain expired sessions error: %v", err)
-		}
-
-		if len(expiredSessionKeys) > 0 {
-			// Remove the expired sessions from the database
-			err = db.Update(func(txu *bolt.Tx) error {
-				// Get the bucket
-				b := txu.Bucket(options.BucketName)
-				if b == nil {
-					return nil
-				}
-
-				// Remove all expired sessions in the slice
-				for _, key := range expiredSessionKeys {
-					err = b.Delete(key)
+					session, err := shared.Session(v)
 					if err != nil {
-						return err
+						// Just remove the session with the invalid session data.
+						// Log the error first.
+						log.Printf("boltstore: removing session from database with invalid value: %v", err)
+						isExpired = true
+					} else if shared.Expired(session) {
+						isExpired = true
+					}
+
+					if isExpired {
+						// Copy the byte slice key, because this data is
+						// not safe outside of this transaction.
+						temp := make([]byte, len(k))
+						copy(temp, k)
+
+						// Add it to the expired sessios keys slice
+						expiredSessionKeys = append(expiredSessionKeys, temp)
+					}
+
+					if options.BatchSize == i {
+						// Store the current key to the previous key.
+						// Copy the byte slice key, because this data is
+						// not safe outside of this transaction.
+						prevKey = make([]byte, len(k))
+						copy(prevKey, k)
+						return nil
 					}
 				}
-
-				return nil
 			})
 
 			if err != nil {
-				log.Printf("boltstore: remove expired sessions error: %v", err)
+				log.Printf("boltstore: obtain expired sessions error: %v", err)
+			}
+
+			if len(expiredSessionKeys) > 0 {
+				// Remove the expired sessions from the database
+				err = db.Update(func(txu *bolt.Tx) error {
+					// Get the bucket
+					b := txu.Bucket(options.BucketName)
+					if b == nil {
+						return nil
+					}
+
+					// Remove all expired sessions in the slice
+					for _, key := range expiredSessionKeys {
+						err = b.Delete(key)
+						if err != nil {
+							return err
+						}
+					}
+
+					return nil
+				})
+
+				if err != nil {
+					log.Printf("boltstore: remove expired sessions error: %v", err)
+				}
 			}
 		}
-
-		// Check if a quit signal is sent.
-		select {
-		case <-quitC:
-			doneC <- struct{}{}
-			return
-		default:
-		}
-
-		time.Sleep(options.CheckInterval)
 	}
 }

--- a/reaper/reaper_test.go
+++ b/reaper/reaper_test.go
@@ -1,10 +1,10 @@
 package reaper
 
 import (
+	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
 	"testing"
 	"time"
-	"code.google.com/p/gogoprotobuf/proto"
 
 	"github.com/boltdb/bolt"
 	"github.com/yosssi/boltstore/shared"
@@ -62,7 +62,12 @@ func Test_reap(t *testing.T) {
 
 	// When shared.Session returns an error
 	err = db.Update(func(tx *bolt.Tx) error {
-		return tx.Bucket(bucketName).Put([]byte("test"), []byte("value"))
+		session := shared.NewSession([]byte{}, -1)
+		data, err := proto.Marshal(session)
+		if err != nil {
+			return err
+		}
+		return tx.Bucket(bucketName).Put([]byte("test"), data)
 	})
 	if err != nil {
 		t.Error(err.Error())

--- a/shared/consts.go
+++ b/shared/consts.go
@@ -15,6 +15,6 @@ const (
 
 // Defaults for reaper.Options
 const (
-	DefaultBatchSize     = 10
-	DefaultCheckInterval = time.Second
+	DefaultBatchSize     = 100
+	DefaultCheckInterval = time.Minute
 )


### PR DESCRIPTION
* Batched multiple database write transactions into one single transaction to improve the bolt database performance.
* Fixed an error in reaper_test.go.
* Increased DefaultCheckInterval and DefaultBatchSize to a higher value. This will improve the bolt store read database access speed. 1 second for the reaper is not needed.
*  Improved the reap loop function to not block on a high options.CheckInterval value. This might block a Quit request for a complete CheckInterval timeout. Fixed this with a ticker and by listening parallel on the ticker and the quit signal.