### PR TITLE
Change all references to code.google.com/p/gogoprotobuf to github.com…

### DIFF
--- a/reaper/reaper_test.go
+++ b/reaper/reaper_test.go
@@ -1,8 +1,8 @@
 package reaper
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	"testing"
 	"time"
 

--- a/shared/protobuf/session.pb.go
+++ b/shared/protobuf/session.pb.go
@@ -13,18 +13,18 @@ It has these top-level messages:
 */
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
-import json "encoding/json"
+import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
 import math "math"
 
-// Reference proto, json, and math imports to suppress error if they are not otherwise used.
+// Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = &json.SyntaxError{}
+var _ = fmt.Errorf
 var _ = math.Inf
 
 type Session struct {
-	Values           []byte `protobuf:"bytes,1,opt" json:"Values,omitempty"`
-	ExpiresAt        *int64 `protobuf:"varint,2,opt" json:"ExpiresAt,omitempty"`
+	Values           []byte `protobuf:"bytes,1,opt,name=Values" json:"Values,omitempty"`
+	ExpiresAt        *int64 `protobuf:"varint,2,opt,name=ExpiresAt" json:"ExpiresAt,omitempty"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -44,7 +44,4 @@ func (m *Session) GetExpiresAt() int64 {
 		return *m.ExpiresAt
 	}
 	return 0
-}
-
-func init() {
 }

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -3,7 +3,7 @@ package shared
 import (
 	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/yosssi/boltstore/shared/protobuf"
 )
 

--- a/shared/utils_test.go
+++ b/shared/utils_test.go
@@ -1,11 +1,11 @@
 package shared
 
 import (
+	"github.com/yosssi/boltstore/shared/protobuf"
 	"testing"
 	"time"
-	"github.com/yosssi/boltstore/shared/protobuf"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 func TestSession(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/base32"
 	"encoding/gob"
+	"github.com/gogo/protobuf/proto"
 	"net/http"
 	"strings"
-	"code.google.com/p/gogoprotobuf/proto"
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/securecookie"

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/boltdb/bolt"
 	"github.com/gorilla/securecookie"


### PR DESCRIPTION
…/gogo/protobuf

Due to code.google.com's shutdown, gogoprotobuf moved.  Change all references to point
to the new location and regenerate the protocol buffer handler with the latest version.
