### PR TITLE
reaper: add support for a pre-delete hook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/yosssi/boltstore
+
+go 1.14
+
+require (
+	github.com/boltdb/bolt v1.3.1
+	github.com/gogo/protobuf v1.3.1
+	github.com/gorilla/securecookie v1.1.1
+	github.com/gorilla/sessions v1.2.0
+	golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
+github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
+github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=
+github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c h1:kISX68E8gSkNYAFRFiDU8rl5RIn1sJYKYb/r2vMLDrU=
+golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -15,6 +15,9 @@ type Options struct {
 	BatchSize int
 	// CheckInterval represents the interval between the reaper's invocation.
 	CheckInterval time.Duration
+	// PreDeleteFn register a function to be called before deleting a session.
+	// If a non-nil error is returned, the session won't be deleted
+	PreDeleteFn func(values map[interface{}]interface{}) error
 }
 
 // setDefault sets default to the reaper options.

--- a/reaper/reaper_test.go
+++ b/reaper/reaper_test.go
@@ -77,6 +77,12 @@ func Test_reap(t *testing.T) {
 	Quit(quitC, doneC)
 
 	// When the target session is expired
+	predeleteFlag := false
+	options.PreDeleteFn = func(values map[interface{}]interface{}) error {
+		predeleteFlag = true
+		return nil
+	}
+	options.CheckInterval = 2 * time.Second
 	err = db.Update(func(tx *bolt.Tx) error {
 		err := tx.Bucket(bucketName).Delete([]byte("test"))
 		if err != nil {
@@ -93,8 +99,11 @@ func Test_reap(t *testing.T) {
 		t.Error(err.Error())
 	}
 	go reap(db, options, quitC, doneC)
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	Quit(quitC, doneC)
+	if !predeleteFlag {
+		t.Fatal("pre-delete function did not run")
+	}
 
 	// When options.BatchSize == i
 	err = db.Update(func(tx *bolt.Tx) error {

--- a/reaper/reaper_test.go
+++ b/reaper/reaper_test.go
@@ -104,6 +104,13 @@ func Test_reap(t *testing.T) {
 	if !predeleteFlag {
 		t.Fatal("pre-delete function did not run")
 	}
+	db.View(func(tx *bolt.Tx) error {
+		val := tx.Bucket(bucketName).Get([]byte("test"))
+		if val != nil {
+			t.Fatal("Key 'test' was not deleted by reaper")
+		}
+		return nil
+	})
 
 	// When options.BatchSize == i
 	err = db.Update(func(tx *bolt.Tx) error {

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -13,7 +13,7 @@ func TestConfig_setDefault(t *testing.T) {
 		t.Errorf("config.SessionOptions.Path should be %s (actual: %s)", shared.DefaultPath, config.SessionOptions.Path)
 	}
 	if config.SessionOptions.MaxAge != shared.DefaultMaxAge {
-		t.Errorf("config.SessionOptions.MaxAge should be %s (actual: %s)", shared.DefaultMaxAge, config.SessionOptions.MaxAge)
+		t.Errorf("config.SessionOptions.MaxAge should be %d (actual: %d)", shared.DefaultMaxAge, config.SessionOptions.MaxAge)
 	}
 	if string(config.DBOptions.BucketName) != shared.DefaultBucketName {
 		t.Errorf("config.SessionOptions.BucketName should be %+v (actual: %+v)", shared.DefaultBucketName, config.DBOptions.BucketName)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -266,8 +266,8 @@ func TestStore_load(t *testing.T) {
 		t.Error(err)
 	}
 	_, err = str.load(session)
-	if err == nil || err.Error() != "proto: protobuf.Session: wiretype end group for non-group" {
-		t.Errorf(`str.load should return an error "%s" (actual: %s)`, "proto: protobuf.Session: wiretype end group for non-group", err)
+	if err == nil || err.Error() != "proto: can't skip unknown wire type 4" {
+		t.Errorf(`str.load should return an error "%s" (actual: %s)`, "proto: can't skip unknown wire type 4", err)
 	}
 
 	// When the target session data is expired

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -318,7 +318,7 @@ func TestSession_delete(t *testing.T) {
 	err = str.delete(session)
 
 	if err.Error() != "database not open" {
-		t.Error(`str.delete should return an error "%s" (actual: %s)`, "database not open", err)
+		t.Errorf(`str.delete should return an error "%s" (actual: %s)`, "database not open", err)
 	}
 }
 
@@ -336,7 +336,7 @@ func TestNew(t *testing.T) {
 		[]byte("secret-key"),
 	)
 	if err.Error() != "database not open" {
-		t.Error(`str.delete  should return an error "%s" (actual: %s)`, "database not open", err)
+		t.Errorf(`str.delete  should return an error "%s" (actual: %s)`, "database not open", err)
 	}
 }
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: yosssi/golang-latest@1.0.7
+box: golang:1.14
 # Build definition
 build:
   # The steps that will be executed on build

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,7 +13,7 @@ build:
         code: |
           cd $WERCKER_SOURCE_DIR
           go version
-          go get -t ./...
+          go mod download
 
     # Build the project
     - script:


### PR DESCRIPTION
Resolves: #10

Changes organized in commits:
* Add Go module support (`go mod init`)
* Fix small formatting errors inside logging functions.
* Add a `PredeleteFn` hook in reaper's options. Reaper will call the `PredeleteFn` with the session values. If the `PredeleteFn` returns an error, the key won't be deleted.
* Fix unit tests:
    * Load unit test hanged, presumably because of a deadlock, because it opened a write transaction while inside a read transaction.
    * Check that keys are actually reaped for reaper unit test.
    * Protobuf error seems to have changed, so update it.

The wercker test doesn't pass because of a very old go version I presume.
Is there any way to update the box? Using docker images doesn't seem to work (I specified `golang:1.14`)